### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This project implements a Model Context Protocol (MCP) server that acts as a bri
 
 It allows the LLM to request and retrieve health and fitness data from a user's Fitbit account via defined tools.
 
+<a href="https://glama.ai/mcp/servers/@TheDigitalNinja/mcp-fitbit">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TheDigitalNinja/mcp-fitbit/badge" alt="Fitbit Server MCP server" />
+</a>
+
 ## Features
 
 *   **Fitbit API Integration:** Connects securely to the Fitbit API using OAuth 2.0.


### PR DESCRIPTION
This PR adds a badge for the [Fitbit MCP Server](https://glama.ai/mcp/servers/@TheDigitalNinja/mcp-fitbit) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@TheDigitalNinja/mcp-fitbit">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TheDigitalNinja/mcp-fitbit/badge" alt="Fitbit Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.