### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,14 @@
 name: CI
 
+permissions:
+  contents: read
+  statuses: write
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/TheDigitalNinja/mcp-fitbit/security/code-scanning/1](https://github.com/TheDigitalNinja/mcp-fitbit/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow's steps:
- Most steps only require `contents: read` to access the repository's code.
- The `coverallsapp/github-action` step uses the `GITHUB_TOKEN`, which may require additional permissions. According to the documentation, it likely needs `contents: read` and possibly `statuses: write` to update commit statuses.

We will add the following `permissions` block at the root of the workflow:
```yaml
permissions:
  contents: read
  statuses: write
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
